### PR TITLE
Solves ValueError (using same graph)

### DIFF
--- a/run_keras_server.py
+++ b/run_keras_server.py
@@ -10,6 +10,7 @@
 from keras.applications import ResNet50
 from keras.preprocessing.image import img_to_array
 from keras.applications import imagenet_utils
+import tensorflow as tf
 from PIL import Image
 import numpy as np
 import flask
@@ -25,6 +26,9 @@ def load_model():
 	# substitute in your own networks just as easily)
 	global model
 	model = ResNet50(weights="imagenet")
+	global graph
+	# save graph after loading ResNet50 weights
+	graph = tf.get_default_graph()
 
 def prepare_image(image, target):
 	# if the image mode is not RGB, convert it
@@ -58,7 +62,9 @@ def predict():
 
 			# classify the input image and then initialize the list
 			# of predictions to return to the client
-			preds = model.predict(image)
+			# use the same graph saved after loading the model
+			with graph.as_default():
+				preds = model.predict(image)
 			results = imagenet_utils.decode_predictions(preds)
 			data["predictions"] = []
 


### PR DESCRIPTION
Solves: `ValueError` problem because of not saving the graph just after loading the pre-trained weights of `ResNet50`.

**Error:** 
(at execution of `model.predict(image)`)

`ValueError: Tensor Tensor("fc1000/Softmax:0", shape=(?, 1000), dtype=float32) is not an element of this graph.`

**System details**:
Ubuntu 18.04
Keras Version: 2.1.6
Tensorflow Version: 1.8.0
Python Version: Python 3.6.5

Reference: https://github.com/tensorflow/tensorflow/issues/14356#issuecomment-385962623